### PR TITLE
Improve the rymdport package with correct data

### DIFF
--- a/rymdport/package.yml
+++ b/rymdport/package.yml
@@ -1,15 +1,14 @@
 name       : rymdport
 version    : 3.2.0
-release    : 2
+release    : 3
 source     :
-    - https://github.com/Jacalz/rymdport/archive/refs/tags/v3.2.0.tar.gz : a630946f5bac0f8eb8dadd4f839e1cef52605b3d0224fc2c9b21b165655fa593
+    - https://github.com/Jacalz/rymdport/releases/download/v3.2.0/rymdport-v3.2.0-vendored.tar.xz : e6f01410ac5f8c46caddad21bb14e8cd67241c685be10ffceeb852bc071778d3
 license    : GPL-3.0-or-later
-homepage   : https://github.com/Jacalz/wormhole-gui
+homepage   : https://github.com/Jacalz/rymdport
 component  : network.client
-summary    : Wormhole-gui is a cross-platform graphical interface for magic-wormhole
+summary    : Easy encrypted file, folder, and text sharing between devices.
 description: |
-    Wormhole-gui is a cross-platform graphical interface for magic-wormhole that lets you easily share files, folders and text between devices. It uses the Go implementation of magic-wormhole, called wormhole-william, and compiles statically into a single binary. Wormhole-gui is compatible with the cli applications from both wormhole-william and magic-wormhole.
-networking : yes
+    Rymdport (formerly wormhole-gui) is a cross-platform application that lets you easily and safely share files, folders, and text between devices. The data is sent securely with end-to-end encryption using the same protocol as magic-wormhole. This means that Rymdport can talk not only to itself, but also to other wormhole clients.
 builddeps  :
     - pkgconfig(gl)
     - pkgconfig(x11)
@@ -21,7 +20,7 @@ builddeps  :
     - golang
 build      : |
     # something with ldflags is not working, so skip them
-    go build -o rymdport
+    go build -trimpath -o rymdport
 install    : |
     %make_install
     # Correct icon location, thanks Archbros


### PR DESCRIPTION
Thanks for packaging my application. I noticed that a few things were out of date so I updated texts and switch to the same tarball that I use for flatpaks which avoids neeting networking during build time. I also added `-trimpath` for fully reproducible builds (that ldflag issue when running `make` will be fixed with the next release).

Would you by any chance be interested in maintaining this in the offical Solus repos? I would gladly appreciate it if you did so :)

NOTE: I have to tested this path as I don't run Solus any more. You might need to run it to make sure but I think it should be fine. As you probably know, I used to be a package maintainer for Solus a few years back. 